### PR TITLE
feat: upsert billing users from LS webhooks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -135,7 +135,57 @@ async function handleWebhook(request, env) {
 
   if (!email) return text(400, "Missing email");
 
-  const payload = [{ email, name, role: "user", group: PLAN_GROUP_MAP.free }];
+  // Determine tier based on Lemon Squeezy variant ID
+  const variantId = String(attrs.variant_id || "");
+  let tier = "free";
+  if (variantId === String(env.STUDENT_VARIANT_ID)) tier = "student";
+  if (variantId === String(env.STANDARD_VARIANT_ID)) tier = "standard";
+  if (variantId === String(env.PRO_VARIANT_ID)) tier = "pro";
+
+  const lemon_customer_id = attrs.customer_id || null;
+  const lemon_subscription_id = body?.data?.id || null;
+  const status = attrs.status || null;
+
+  const sbKey = env.SUPABASE_SERVICE_KEY || env.SUPABASE_KEY;
+  if (!env.SUPABASE_URL || !sbKey) {
+    return text(500, "Missing Supabase config");
+  }
+
+  // Upsert into billing_users and return the stored row
+  const [row] = await fetchJSON(
+    `${env.SUPABASE_URL}/rest/v1/billing_users?on_conflict=email`,
+    {
+      method: "POST",
+      headers: {
+        apikey: sbKey,
+        Authorization: `Bearer ${sbKey}`,
+        "content-type": "application/json",
+        Prefer: "resolution=merge-duplicates,return=representation",
+      },
+      body: JSON.stringify([
+        { email, tier, lemon_customer_id, lemon_subscription_id, status },
+      ]),
+    },
+  );
+
+  // Optionally create a Supabase Auth user (ignore errors)
+  try {
+    await fetch(`${env.SUPABASE_URL}/auth/v1/admin/users`, {
+      method: "POST",
+      headers: {
+        apikey: sbKey,
+        Authorization: `Bearer ${sbKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ email, email_confirm: true }),
+    });
+  } catch (err) {
+    console.warn("auth create err", err?.message);
+  }
+
+  // Use tier from row to determine OWUI group
+  const group = PLAN_GROUP_MAP[row?.tier] || PLAN_GROUP_MAP.free;
+  const payload = [{ email, name, role: "user", group }];
 
   const res = await fetch(env.OWUI_SYNC_ENDPOINT, {
     method: "POST",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2,19 +2,19 @@ import { env, createExecutionContext, waitOnExecutionContext, SELF } from 'cloud
 import { describe, it, expect } from 'vitest';
 import worker from '../src';
 
-describe('Hello World worker', () => {
-	it('responds with Hello World! (unit style)', async () => {
-		const request = new Request('http://example.com');
-		// Create an empty context to pass to `worker.fetch()`.
-		const ctx = createExecutionContext();
-		const response = await worker.fetch(request, env, ctx);
-		// Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
-		await waitOnExecutionContext(ctx);
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-	});
+describe('worker', () => {
+        it('responds with 404 on unknown path (unit style)', async () => {
+                const request = new Request('http://example.com');
+                // Create an empty context to pass to `worker.fetch()`.
+                const ctx = createExecutionContext();
+                const response = await worker.fetch(request, env, ctx);
+                // Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
+                await waitOnExecutionContext(ctx);
+                expect(await response.text()).toMatchInlineSnapshot(`"Not found"`);
+        });
 
-	it('responds with Hello World! (integration style)', async () => {
-		const response = await SELF.fetch('http://example.com');
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-	});
+        it('responds with 404 on unknown path (integration style)', async () => {
+                const response = await SELF.fetch('http://example.com');
+                expect(await response.text()).toMatchInlineSnapshot(`"Not found"`);
+        });
 });


### PR DESCRIPTION
## Summary
- upsert billing_users in Supabase using service role when Lemon Squeezy webhook fires
- map variant IDs to subscription tiers and forward to OWUI
- create Supabase Auth user for new emails
- update tests for current 404 default response

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9dc0852fc8326937e00bf8237ab6b