### PR TITLE
Sync LS subscription events to Supabase auth and OWUI

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,9 +47,9 @@ export default {
 // -------- Core sync --------
 
 async function runSync(env) {
-  const sbKey = env.SUPABASE_SERVICE_KEY || env.SUPABASE_KEY;
+  const sbKey = env.SUPABASE_SERVICE_ROLE_KEY;
   if (!env.SUPABASE_URL || !sbKey) {
-    throw new Error("Missing SUPABASE_URL or service key");
+    throw new Error("Missing SUPABASE_URL or service role key");
   }
   if (!env.OWUI_SYNC_ENDPOINT || !env.OWUI_AUTH_TOKEN) {
     throw new Error("Missing OWUI_SYNC_ENDPOINT or OWUI_AUTH_TOKEN");
@@ -129,13 +129,107 @@ async function handleWebhook(request, env) {
     return text(400, "Invalid JSON");
   }
 
+  const event = body?.meta?.event_name;
+  if (!["subscription_created", "subscription_updated"].includes(event)) {
+    return text(200, "ignored");
+  }
+
   const attrs = body?.data?.attributes || {};
   const email = (attrs.user_email || "").trim().toLowerCase();
   const name = attrs.user_name || (email ? email.split("@")[0] : "Unknown");
 
   if (!email) return text(400, "Missing email");
 
-  const payload = [{ email, name, role: "user", group: PLAN_GROUP_MAP.free }];
+  const variantId = String(attrs.variant_id || "");
+  let tier = "free";
+  if (variantId === env.STUDENT_VARIANT_ID) tier = "student";
+  else if (variantId === env.STANDARD_VARIANT_ID) tier = "standard";
+  else if (variantId === env.PRO_VARIANT_ID) tier = "pro";
+
+  const sbKey = env.SUPABASE_SERVICE_ROLE_KEY;
+  let row;
+  if (env.SUPABASE_URL && sbKey) {
+    const upsertUrl = `${env.SUPABASE_URL}/rest/v1/billing_users?on_conflict=lemon_subscription_id`;
+    const upsertRes = await fetch(upsertUrl, {
+      method: "POST",
+      headers: {
+        apikey: sbKey,
+        Authorization: `Bearer ${sbKey}`,
+        "Content-Type": "application/json",
+        Prefer: "resolution=merge-duplicates,return=representation",
+      },
+      body: JSON.stringify({
+        email,
+        tier,
+        status: attrs.status,
+        lemon_customer_id: attrs.customer_id,
+        lemon_subscription_id: body?.data?.id || attrs.id,
+        trial_ends_at: attrs.trial_ends_at,
+      }),
+    });
+
+    try {
+      row = (await upsertRes.json())[0];
+    } catch {
+      row = undefined;
+    }
+
+    let authUid;
+    try {
+      const adminUrl = `${env.SUPABASE_URL}/auth/v1/admin/users`;
+      const createRes = await fetch(adminUrl, {
+        method: "POST",
+        headers: {
+          apikey: sbKey,
+          Authorization: `Bearer ${sbKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email, email_confirm: true }),
+      });
+      if (createRes.ok) {
+        const user = await createRes.json();
+        authUid = user.id;
+      } else if (createRes.status === 422 || createRes.status === 409) {
+        const fetchRes = await fetch(`${adminUrl}?email=${encodeURIComponent(email)}`, {
+          headers: { apikey: sbKey, Authorization: `Bearer ${sbKey}` },
+        });
+        if (fetchRes.ok) {
+          const data = await fetchRes.json();
+          authUid = data?.users?.[0]?.id || data?.[0]?.id;
+        }
+      } else {
+        const txt = await createRes.text();
+        console.log("auth admin error", createRes.status, txt);
+      }
+    } catch (err) {
+      console.log("auth admin error", err);
+    }
+
+    if (authUid) {
+      await fetch(
+        `${env.SUPABASE_URL}/rest/v1/billing_users?lemon_subscription_id=eq.${encodeURIComponent(
+          body?.data?.id || attrs.id,
+        )}`,
+        {
+          method: "PATCH",
+          headers: {
+            apikey: sbKey,
+            Authorization: `Bearer ${sbKey}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ auth_uid: authUid }),
+        },
+      );
+      if (row) row.auth_uid = authUid;
+    }
+
+    if (row) {
+      tier = row.tier || tier;
+    }
+  }
+
+  const group = PLAN_GROUP_MAP[tier] || PLAN_GROUP_MAP.free;
+  const payload = [{ email, name, role: "user", group }];
 
   const res = await fetch(env.OWUI_SYNC_ENDPOINT, {
     method: "POST",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,20 +1,13 @@
-import { env, createExecutionContext, waitOnExecutionContext, SELF } from 'cloudflare:test';
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
 import { describe, it, expect } from 'vitest';
 import worker from '../src';
 
-describe('Hello World worker', () => {
-	it('responds with Hello World! (unit style)', async () => {
-		const request = new Request('http://example.com');
-		// Create an empty context to pass to `worker.fetch()`.
-		const ctx = createExecutionContext();
-		const response = await worker.fetch(request, env, ctx);
-		// Wait for all `Promise`s passed to `ctx.waitUntil()` to settle before running test assertions
-		await waitOnExecutionContext(ctx);
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-	});
-
-	it('responds with Hello World! (integration style)', async () => {
-		const response = await SELF.fetch('http://example.com');
-		expect(await response.text()).toMatchInlineSnapshot(`"Hello World!"`);
-	});
+describe('worker basics', () => {
+  it('returns 404 for unknown routes', async () => {
+    const request = new Request('http://example.com/');
+    const ctx = createExecutionContext();
+    const res = await worker.fetch(request, env, ctx);
+    await waitOnExecutionContext(ctx);
+    expect(res.status).toBe(404);
+  });
 });


### PR DESCRIPTION
## Summary
- Use SUPABASE_SERVICE_ROLE_KEY consistently for Supabase access
- Upsert Lemon Squeezy subscription data to `billing_users` and link Supabase Auth UID
- Map subscription variants to tiers and sync resulting group to OWUI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b9e8d1674c8326ae2af42ce3038130